### PR TITLE
feat: toggle drawer until guide selected

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -46,6 +46,7 @@ fun GuidesApp() {
 
     ModalNavigationDrawer(
         drawerState = drawerState,
+        gesturesEnabled = selectedGuide != null,
         drawerContent = {
             ModalDrawerSheet {
                 Text(
@@ -71,17 +72,19 @@ fun GuidesApp() {
                 CenterAlignedTopAppBar(
                     title = { Text(selectedGuide ?: "Guías Clínicas") },
                     navigationIcon = {
-                        IconButton(onClick = {
-                            scope.launch {
-                                if (drawerState.isClosed) drawerState.open() else drawerState.close()
+                        if (selectedGuide != null) {
+                            IconButton(onClick = {
+                                scope.launch {
+                                    if (drawerState.isClosed) drawerState.open() else drawerState.close()
+                                }
+                            }) {
+                                Icon(Icons.Default.Menu, contentDescription = "Abrir menú")
                             }
-                        }) {
-                            Icon(Icons.Default.Menu, contentDescription = "Abrir menú")
                         }
                     },
                     actions = {
                         IconButton(onClick = { menuExpanded = true }) {
-                            Icon(Icons.Default.MoreVert, contentDescription = "Seleccionar guía")
+                            Icon(Icons.Default.MenuBook, contentDescription = "Seleccionar guía")
                         }
                         DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
                             DropdownMenuItem(


### PR DESCRIPTION
## Summary
- disable drawer and hamburger menu until a guide is selected
- replace guide selector's three-dot icon with a book icon

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ac5d4ebc8320a482a48c46c079b6