### PR TITLE
Fix unresolved MenuBook icon and add error handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -84,7 +84,7 @@ fun GuidesApp() {
                     },
                     actions = {
                         IconButton(onClick = { menuExpanded = true }) {
-                            Icon(Icons.Default.MenuBook, contentDescription = "Seleccionar guía")
+                            Icon(Icons.Filled.MenuBook, contentDescription = "Seleccionar guía")
                         }
                         DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
                             DropdownMenuItem(
@@ -129,8 +129,10 @@ fun GuidesApp() {
                 }
             }
         ) { innerPadding ->
-            val text = selectedChapter?.let { "Detalles ficticios de $it de ${selectedGuide}" }
-                ?: "Selecciona un capítulo"
+            val text = runCatching {
+                selectedChapter?.let { "Detalles ficticios de $it de ${selectedGuide}" }
+                    ?: "Selecciona un capítulo"
+            }.getOrElse { "Error al cargar la información" }
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- include Material Icons Extended and use MenuBook icon for guide selector
- add runCatching wrapper to display fallback message on errors

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae02d888832094b01457348b27b9