### PR TITLE
Ensure navigation drawer stays open after guide selection

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -44,6 +44,12 @@ fun GuidesApp() {
         else -> emptyList()
     }
 
+    LaunchedEffect(selectedGuide) {
+        if (selectedGuide != null) {
+            drawerState.open()
+        }
+    }
+
     ModalNavigationDrawer(
         drawerState = drawerState,
         gesturesEnabled = selectedGuide != null,
@@ -93,7 +99,6 @@ fun GuidesApp() {
                                     selectedGuide = "HTA 2025"
                                     selectedChapter = null
                                     menuExpanded = false
-                                    scope.launch { drawerState.open() }
                                 }
                             )
                             DropdownMenuItem(
@@ -102,7 +107,6 @@ fun GuidesApp() {
                                     selectedGuide = "SCA 2025"
                                     selectedChapter = null
                                     menuExpanded = false
-                                    scope.launch { drawerState.open() }
                                 }
                             )
                         }


### PR DESCRIPTION
## Summary
- Use LaunchedEffect to open the drawer after a guide is picked, keeping it visible on first selection
- Clean up menu item handlers by removing manual drawer open calls

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a3b0b959ec8320a468a045df0b9c61