### PR TITLE
Handle overlapping highlight ranges

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/HighlightedText.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/HighlightedText.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import kotlin.math.max
 
 /**
  * Pinta todas las coincidencias en amarillo y, si [focus] no es null,
@@ -37,18 +38,20 @@ fun buildHighlighted(
     return buildAnnotatedString {
         var cursor = 0
         for (r in closed) {
+            val start = max(cursor, r.first)
             // Texto previo sin resaltar
-            if (cursor < r.first) append(text.substring(cursor, r.first))
+            if (cursor < start) append(text.substring(cursor, start))
 
             // Substring del rango r (ojo: .last es inclusivo → endExcl = last + 1)
             val endExcl = r.last + 1
             val style   = if (focusClosed != null && r == focusClosed) greenBg else yellowBg
 
-            pushStyle(style)
-            append(text.substring(r.first, endExcl))
-            pop()
-
-            cursor = endExcl
+            if (start < endExcl) {
+                pushStyle(style)
+                append(text.substring(start, endExcl))
+                pop()
+                cursor = endExcl
+            }
         }
         if (cursor < text.length) append(text.substring(cursor))
     }

--- a/app/src/test/java/com/gio/guiasclinicas/HighlightedTextTest.kt
+++ b/app/src/test/java/com/gio/guiasclinicas/HighlightedTextTest.kt
@@ -1,0 +1,27 @@
+package com.gio.guiasclinicas
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import com.gio.guiasclinicas.ui.components.buildHighlighted
+
+class HighlightedTextTest {
+    @Test
+    fun overlapping_ranges_do_not_duplicate_characters() {
+        val result = buildHighlighted("aaa", listOf(0..1, 1..2), null)
+        // texto completo sin duplicados
+        assertEquals("aaa", result.text)
+        assertEquals(3, result.text.length)
+
+        // dos zonas amarillas
+        assertEquals(2, result.spanStyles.size)
+        val yellow = Color(0xFFFFF59D)
+        for (span in result.spanStyles) {
+            assertEquals(yellow, span.item.background)
+        }
+        assertEquals(0, result.spanStyles[0].start)
+        assertEquals(2, result.spanStyles[0].end)
+        assertEquals(2, result.spanStyles[1].start)
+        assertEquals(3, result.spanStyles[1].end)
+    }
+}


### PR DESCRIPTION
## Summary
- Avoid duplicating characters when highlighting overlapping ranges by starting each segment at `max(cursor, r.first)`
- Add unit test covering overlapping range scenario

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae855eed208320b8e9d58f52574e90