### PR TITLE
Reset search highlight state before new searches

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/viewmodel/GuidesViewModel.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/viewmodel/GuidesViewModel.kt
@@ -268,6 +268,10 @@ class GuidesViewModel(app: Application) : AndroidViewModel(app) {
     ) {
         Log.d(TAG, "startSearchAll(raw='$rawQuery', flags=$flags)")
         if (rawQuery.isBlank()) return
+        _activeHighlight.value = null
+        _chapterHits.value = emptyList()
+        _currentChapterHitIndex.value = 0
+        currentHitIndex = 0
         rememberQuery(rawQuery)
 
         val norm  = rawQuery.normalizeForSearch(flags).normalized
@@ -318,6 +322,10 @@ class GuidesViewModel(app: Application) : AndroidViewModel(app) {
     ) {
         Log.d(TAG, "startSearch(dir=$guideDir, slug=$guideSlug, raw='$rawQuery', flags=$flags)")
         if (rawQuery.isBlank()) return
+        _activeHighlight.value = null
+        _chapterHits.value = emptyList()
+        _currentChapterHitIndex.value = 0
+        currentHitIndex = 0
         rememberQuery(rawQuery)
 
         val norm  = rawQuery.normalizeForSearch(flags).normalized
@@ -371,6 +379,10 @@ class GuidesViewModel(app: Application) : AndroidViewModel(app) {
     ) {
         Log.d(TAG, "startSearchInActiveChapter(raw='$rawQuery', flags=$flags)")
         if (rawQuery.isBlank()) return
+        _activeHighlight.value = null
+        _chapterHits.value = emptyList()
+        _currentChapterHitIndex.value = 0
+        currentHitIndex = 0
 
         val dir   = currentGuideDir
         val ch    = currentChapterPath


### PR DESCRIPTION
## Summary
- clear active highlight and chapter hit tracking before starting any search
- reset current hit index to 0 prior to emitting new search state

## Testing
- ⚠️ `./gradlew test` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ae856363e883209830ff9c1c29df63