### PR TITLE
Handle multiple matches per hit in chapter view

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -216,6 +216,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             ) {
                 val chapterState by vm.chapterState.collectAsStateWithLifecycle()
                 val pendingHit   by vm.pendingFocus.collectAsStateWithLifecycle()
+                val matchIndex   by vm.currentMatchIndex.collectAsStateWithLifecycle()
 
                 // --- REEMPLAZA SOLO ESTA LLAMADA ---
 
@@ -235,6 +236,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                     state = chapterState,
                     pendingHit = pendingHit,                 // solo para hacer scroll una vez
                     activeHighlight = activeHit,             // ← este mantiene el verde
+                    activeMatchIndex = matchIndex,
                     onHitConsumed = { vm.consumePendingFocus() },
 
                     totalHits = readyUi?.results?.hits?.size ?: 0,

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -132,6 +132,7 @@ fun ChapterContentViewWithSearch(
     state: com.gio.guiasclinicas.ui.state.ChapterUiState,
     pendingHit: SearchHit?,          // solo para hacer scroll al llegar
     activeHighlight: SearchHit?,     // el hit activo que debe quedar pintado (verde)
+    activeMatchIndex: Int,
     onHitConsumed: () -> Unit,
 
     totalHits: Int,
@@ -189,7 +190,7 @@ fun ChapterContentViewWithSearch(
                                         if (isThis && (part == null || part == "body"))
                                             activeHighlight?.matchRanges ?: emptyList()
                                         else emptyList()
-                                    val focus: IntRange? = bodyMatches.firstOrNull()
+                                    val focus: IntRange? = bodyMatches.getOrNull(activeMatchIndex)
 
                                     Text(
                                         text = if (bodyMatches.isEmpty()) AnnotatedString(body)
@@ -206,7 +207,7 @@ fun ChapterContentViewWithSearch(
                                         if (isThis && part == "footnote")
                                             activeHighlight?.matchRanges ?: emptyList()
                                         else emptyList()
-                                    val footFocus = footMatches.firstOrNull()
+                                    val footFocus = footMatches.getOrNull(activeMatchIndex)
 
                                     Spacer(Modifier.height(6.dp))
                                     Text(


### PR DESCRIPTION
## Summary
- Track match index inside active SearchHit in `GuidesViewModel`
- Highlight the selected match in `ChapterContentViewWithSearch`
- Pass match index from `MainActivity` and update navigation

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae856489048320a8f6aa7b7ce4b0e5