### PR TITLE
Improve search hit navigation with per-match indexing

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.launch
 /// MainActivity.kt — imports NUEVOS
 import com.gio.guiasclinicas.data.search.SearchUiState
 import com.gio.guiasclinicas.ui.state.ChapterUiState
-import com.gio.guiasclinicas.data.search.SearchHit
 import com.gio.guiasclinicas.ui.components.FavoritesSheet
 
 
@@ -217,27 +216,19 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                 val chapterState by vm.chapterState.collectAsStateWithLifecycle()
                 val pendingHit   by vm.pendingFocus.collectAsStateWithLifecycle()
 
-                // --- REEMPLAZA SOLO ESTA LLAMADA ---
-
-                // Antes de la llamada:
-                val uiReady = (searchUi as? SearchUiState.Ready)
-                val chapterSlug = (chapterState as? ChapterUiState.Ready)?.content?.chapter?.slug
-                val chapterHits: List<SearchHit> =
-                    uiReady?.results?.hits?.filter { it.chapterSlug == chapterSlug } ?: emptyList()
-
-                // Estado de búsqueda para overlay y foco activo
                 val uiState by vm.searchUi.collectAsStateWithLifecycle()
                 val readyUi = uiState as? SearchUiState.Ready
-                val activeHit = readyUi?.results?.hits?.getOrNull(readyUi.currentHitIndex)
+                val activeHit by vm.activeHighlight.collectAsStateWithLifecycle()
+                val matchIdx by vm.currentMatchIndex.collectAsStateWithLifecycle()
 
-// Llama ahora con el nuevo parámetro chapterHits
                 ChapterContentViewWithSearch(
                     state = chapterState,
                     pendingHit = pendingHit,                 // solo para hacer scroll una vez
                     activeHighlight = activeHit,             // ← este mantiene el verde
+                    currentMatchIndex = matchIdx,
                     onHitConsumed = { vm.consumePendingFocus() },
 
-                    totalHits = readyUi?.results?.hits?.size ?: 0,
+                    totalHits = readyUi?.results?.total ?: 0,
                     currentHitIndex = readyUi?.currentHitIndex ?: 0,
                     onPrev = vm::goToPrevHit,
                     onNext = vm::goToNextHit,

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -132,6 +132,7 @@ fun ChapterContentViewWithSearch(
     state: com.gio.guiasclinicas.ui.state.ChapterUiState,
     pendingHit: SearchHit?,          // solo para hacer scroll al llegar
     activeHighlight: SearchHit?,     // el hit activo que debe quedar pintado (verde)
+    currentMatchIndex: Int,
     onHitConsumed: () -> Unit,
 
     totalHits: Int,
@@ -189,7 +190,7 @@ fun ChapterContentViewWithSearch(
                                         if (isThis && (part == null || part == "body"))
                                             activeHighlight?.matchRanges ?: emptyList()
                                         else emptyList()
-                                    val focus: IntRange? = bodyMatches.firstOrNull()
+                                    val focus: IntRange? = bodyMatches.getOrNull(currentMatchIndex)
 
                                     Text(
                                         text = if (bodyMatches.isEmpty()) AnnotatedString(body)
@@ -206,7 +207,7 @@ fun ChapterContentViewWithSearch(
                                         if (isThis && part == "footnote")
                                             activeHighlight?.matchRanges ?: emptyList()
                                         else emptyList()
-                                    val footFocus = footMatches.firstOrNull()
+                                    val footFocus = footMatches.getOrNull(currentMatchIndex)
 
                                     Spacer(Modifier.height(6.dp))
                                     Text(


### PR DESCRIPTION
## Summary
- Track current match index within each search hit
- Navigate within a hit before moving to adjacent hits
- Highlight the correct match and display global match counts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae90e305688320a02d23afa1d83dc4