### PR TITLE
Support search highlights in table footnotes

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
@@ -70,7 +70,11 @@ fun ShouldUseBigTable(section: TableSection): Boolean {
  *  celdas con altura uniforme, elipsis + diálogo, paginación y fade derecho.
  * ---------------------------------------------------------------------- */
 @Composable
-fun BigTableSectionView(section: TableSection) {
+fun BigTableSectionView(
+    section: TableSection,
+    footnoteMatches: List<IntRange> = emptyList(),
+    footnoteFocus: IntRange? = null
+) {
     val theme = LocalTableTheme.current
     val cols = section.columns
     val allRows = section.rows
@@ -256,7 +260,8 @@ fun BigTableSectionView(section: TableSection) {
             section.footnote?.let { note ->
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = note,
+                    text = if (footnoteMatches.isEmpty()) AnnotatedString(note)
+                    else buildHighlighted(note, footnoteMatches, footnoteFocus),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -220,8 +220,21 @@ fun ChapterContentViewWithSearch(
                             }
 
                             is TableSection -> {
-                                // No tocamos celdas aquí para no romper BigTable
-                                TableSectionView(section)
+                                // Resaltado opcional solo para el pie de tabla
+                                val isThis = sameSection(section, index, activeHighlight?.sectionId)
+                                val part   = partOf(activeHighlight?.sectionId)
+                                val footMatches: List<IntRange> =
+                                    if (isThis && part == "footnote")
+                                        activeHighlight?.matchRanges ?: emptyList()
+                                    else emptyList()
+                                val footFocus = footMatches.getOrNull(currentMatchIndex)
+
+                                // No tocamos celdas para no romper BigTable
+                                TableSectionView(
+                                    section = section,
+                                    footnoteMatches = footMatches,
+                                    footnoteFocus = footFocus
+                                )
                             }
 
                             is ImageSection -> ImageSectionView(section)

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/GuideTable.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/GuideTable.kt
@@ -39,18 +39,22 @@ import kotlin.math.max
 // Selector de renderer según variante
 // ======================================================
 @Composable
-fun TableSectionView(section: TableSection) {
+fun TableSectionView(
+    section: TableSection,
+    footnoteMatches: List<IntRange> = emptyList(),
+    footnoteFocus: IntRange? = null
+) {
     if (section.variant.isRecommendationVariant()) {
         // Las tablas de recomendaciones mantienen su renderer propio
         RecommendationTableTheme {
-            RecommendationTableView(section)
+            RecommendationTableView(section, footnoteMatches, footnoteFocus)
         }
     } else {
         // Para el resto, usar el renderer Pro solo si la tabla es ancha y densa
         if (ShouldUseBigTable(section)) {
-            BigTableSectionView(section)
+            BigTableSectionView(section, footnoteMatches, footnoteFocus)
         } else {
-            StandardTableSectionView(section)
+            StandardTableSectionView(section, footnoteMatches, footnoteFocus)
         }
     }
 }
@@ -72,7 +76,11 @@ private fun String?.isRecommendationVariant(): Boolean {
 // ======================================================
 @Suppress("BoxWithConstraintsScope")
 @Composable
-private fun StandardTableSectionView(section: TableSection) {
+private fun StandardTableSectionView(
+    section: TableSection,
+    footnoteMatches: List<IntRange> = emptyList(),
+    footnoteFocus: IntRange? = null
+) {
     val cols = section.columns
     val rows = section.rows
     val theme = LocalTableTheme.current
@@ -255,7 +263,8 @@ private fun StandardTableSectionView(section: TableSection) {
         section.footnote?.let { note ->
             Spacer(Modifier.height(8.dp))
             Text(
-                text = note,
+                text = if (footnoteMatches.isEmpty()) AnnotatedString(note)
+                else buildHighlighted(note, footnoteMatches, footnoteFocus),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -300,7 +309,11 @@ private fun StandardCell(
 
 @Suppress("BoxWithConstraintsScope")
 @Composable
-private fun RecommendationTableView(section: TableSection) {
+private fun RecommendationTableView(
+    section: TableSection,
+    footnoteMatches: List<IntRange> = emptyList(),
+    footnoteFocus: IntRange? = null
+) {
     val cols = section.columns
     val rows = section.rows
     val spec = LocalRecTableTheme.current
@@ -493,7 +506,8 @@ private fun RecommendationTableView(section: TableSection) {
         section.footnote?.let { note ->
             Spacer(Modifier.height(8.dp))
             Text(
-                text = note,
+                text = if (footnoteMatches.isEmpty()) AnnotatedString(note)
+                else buildHighlighted(note, footnoteMatches, footnoteFocus),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )


### PR DESCRIPTION
## Summary
- highlight table footnotes with search matches
- wire match navigation index through table rendering

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7dc192ac8320bc66285de10e491a