### PR TITLE
Highlight image caption search matches

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -237,7 +237,21 @@ fun ChapterContentViewWithSearch(
                                 )
                             }
 
-                            is ImageSection -> ImageSectionView(section)
+                            is ImageSection -> {
+                                val isThis = sameSection(section, index, activeHighlight?.sectionId)
+                                val part   = partOf(activeHighlight?.sectionId)
+                                val captionMatches: List<IntRange> =
+                                    if (isThis && part == "caption")
+                                        activeHighlight?.matchRanges ?: emptyList()
+                                    else emptyList()
+                                val captionFocus = captionMatches.getOrNull(currentMatchIndex)
+
+                                ImageSectionView(
+                                    section = section,
+                                    captionMatches = captionMatches,
+                                    captionFocus = captionFocus
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ImageSectionView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ImageSectionView.kt
@@ -24,7 +24,11 @@ import kotlinx.coroutines.withContext
 import kotlin.math.max
 
 @Composable
-fun ImageSectionView(section: ImageSection) {
+fun ImageSectionView(
+    section: ImageSection,
+    captionMatches: List<IntRange> = emptyList(),
+    captionFocus: IntRange? = null
+) {
     val ctx = LocalContext.current
     val density = LocalDensity.current
     val spec = LocalImageTheme.current
@@ -34,7 +38,7 @@ fun ImageSectionView(section: ImageSection) {
     Column(Modifier.fillMaxWidth()) {
         if (caption != null && spec.captionPlacement == FigureCaptionPlacement.Top) {
             Text(
-                text = caption,
+                text = buildHighlighted(caption, captionMatches, captionFocus),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Start
@@ -91,7 +95,7 @@ fun ImageSectionView(section: ImageSection) {
         if (caption != null && spec.captionPlacement == FigureCaptionPlacement.Bottom) {
             Spacer(Modifier.height(spec.captionSpacingDp.dp))
             Text(
-                text = caption,
+                text = buildHighlighted(caption, captionMatches, captionFocus),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Start


### PR DESCRIPTION
## Summary
- support caption match highlighting in `ImageSectionView`
- forward caption search hits from `ChapterContentViewWithSearch`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b4edd788320bfeb2f39445d2e82