### PR TITLE
Collect table footnote search highlights

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -220,6 +220,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                 val readyUi = uiState as? SearchUiState.Ready
                 val activeHit by vm.activeHighlight.collectAsStateWithLifecycle()
                 val matchIdx by vm.currentMatchIndex.collectAsStateWithLifecycle()
+                val chapterHits by vm.chapterHits.collectAsStateWithLifecycle()
 
                 ChapterContentViewWithSearch(
                     state = chapterState,
@@ -227,6 +228,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                     activeHighlight = activeHit,             // ← este mantiene el verde
                     currentMatchIndex = matchIdx,
                     onHitConsumed = { vm.consumePendingFocus() },
+                    chapterHits = chapterHits,
 
                     totalHits = readyUi?.results?.total ?: 0,
                     currentHitIndex = readyUi?.currentHitIndex ?: 0,


### PR DESCRIPTION
## Summary
- Aggregate table footnote matches from chapterHits and supply them to TableSectionView
- Pass chapterHits from MainActivity into ChapterContentViewWithSearch
- Only focus footnote highlights for the active section

## Testing
- ⚠️ `./gradlew test` *(failed: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b509b6483209fbe411e76a3f630