### PR TITLE
fix: save accordion state map

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gio.guiasclinicas.data.model.*
@@ -58,7 +60,14 @@ fun ChapterContentView(state: ChapterUiState) {
 @Composable
 private fun ChapterBodyView(sections: List<ChapterSection>) {
     val scope = rememberCoroutineScope()
-    val expandedMap = rememberSaveable { mutableStateMapOf<String, Boolean>() }
+    val expandedMap = rememberSaveable(
+        saver = mapSaver(
+            save = { state: SnapshotStateMap<String, Boolean> -> state.toMap() },
+            restore = { restored: Map<String, Boolean> ->
+                mutableStateMapOf<String, Boolean>().apply { putAll(restored) }
+            }
+        )
+    ) { mutableStateMapOf<String, Boolean>() }
 
     ZoomResetHost {
         Column(


### PR DESCRIPTION
## Summary
- save chapter accordion expansion state with `rememberSaveable` using a custom map saver

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68aea534cc7c83208d81f57b601b62c1