### PR TITLE
fix: resolve merge conflict in ChapterContentView

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -12,6 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.toMutableStateMap
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -60,7 +63,12 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
     val scope = rememberCoroutineScope()
     val expandedMap = rememberSaveable(
         saver = mapSaver(
-
+            save = { it.toMap() },
+            restore = { it.toMutableStateMap() }
+        )
+    ) {
+        mutableStateMapOf<String, Boolean>()
+    }
 
     ZoomResetHost {
         Column(


### PR DESCRIPTION
## Summary
- integrate mapSaver and rememberSaveable for expanded sections
- include global expand/collapse buttons with expandedMap

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68af102650ac8320bc62e7016d5a98ee