### PR TITLE
Use SnapshotStateMap for expanded sections

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.toMutableStateMap
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -61,8 +62,8 @@ fun ChapterContentView(state: ChapterUiState) {
 @Composable
 private fun ChapterBodyView(sections: List<ChapterSection>) {
     val scope = rememberCoroutineScope()
-    val expandedMap = rememberSaveable(
-        saver = mapSaver(
+    val expandedMap: SnapshotStateMap<String, Boolean> = rememberSaveable(
+        saver = mapSaver<SnapshotStateMap<String, Boolean>>(
             save = { it.toMap() },
             restore = { it.toMutableStateMap() }
         )


### PR DESCRIPTION
## Summary
- type the `expandedMap` state as `SnapshotStateMap<String, Boolean>` in `ChapterContentView`
- import `SnapshotStateMap`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af317215148320bb2afb9642ad5d19