### PR TITLE
Add basic chapter text search with navigation

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -6,11 +6,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -23,10 +28,18 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.PlainTooltipBox
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +48,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gio.guiasclinicas.ui.components.ClinicalGuidesMenuTopBar
 import com.gio.guiasclinicas.ui.components.ChapterContentView
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.searchSections
+import com.gio.guiasclinicas.ui.state.ChapterUiState
 import com.gio.guiasclinicas.ui.state.GuideDetailUiState
 import com.gio.guiasclinicas.ui.theme.GuiasClinicasTheme
 import com.gio.guiasclinicas.ui.viewmodel.GuidesViewModel
@@ -60,12 +76,29 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
     val detailState by vm.detailState.collectAsStateWithLifecycle()
     val chapterState by vm.chapterState.collectAsStateWithLifecycle()
 
+    var searchVisible by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("ejemplo") }
+    val searchResults = remember { mutableStateListOf<SearchResult>() }
+    var currentResult by remember { mutableStateOf(0) }
+
     // Abre/cierra el drawer según el estado de detalle
     LaunchedEffect(detailState) {
         when (detailState) {
             is GuideDetailUiState.Ready -> drawerState.open()
             GuideDetailUiState.Idle -> drawerState.close()
             else -> Unit
+        }
+    }
+
+    LaunchedEffect(searchQuery, chapterState, searchVisible) {
+        if (searchVisible && chapterState is ChapterUiState.Ready) {
+            val sections = (chapterState as ChapterUiState.Ready).content.content.sections
+            searchResults.clear()
+            searchResults.addAll(searchSections(sections, searchQuery))
+            currentResult = 0
+        } else {
+            searchResults.clear()
+            currentResult = 0
         }
     }
 
@@ -136,7 +169,8 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             bottomBar = {
                 NavigationBar {
                     NavigationBarItem(
-                        selected = false, onClick = {},
+                        selected = searchVisible,
+                        onClick = { searchVisible = !searchVisible },
                         icon = { androidx.compose.material3.Icon(Icons.Filled.Search, contentDescription = "Buscar") }
                     )
                     NavigationBarItem(
@@ -157,7 +191,62 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                 contentAlignment = Alignment.TopStart
             ) {
                 // Renderiza el contenido del capítulo (ready/loading/error/idle)
-                ChapterContentView(state = chapterState)
+                ChapterContentView(state = chapterState, searchResults = searchResults, currentResult = currentResult)
+
+                if (searchVisible) {
+                    ChapterSearchBar(
+                        query = searchQuery,
+                        onQueryChange = { searchQuery = it },
+                        onNext = {
+                            if (searchResults.isNotEmpty()) currentResult = (currentResult + 1) % searchResults.size
+                        },
+                        onPrev = {
+                            if (searchResults.isNotEmpty()) currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                        },
+                        onClose = {
+                            searchVisible = false
+                            searchResults.clear()
+                            currentResult = 0
+                        },
+                        modifier = Modifier.align(Alignment.TopCenter)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onNext: () -> Unit,
+    onPrev: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier = Modifier.weight(1f),
+                singleLine = true
+            )
+            PlainTooltipBox(tooltip = { Text("Anterior") }) {
+                IconButton(onClick = onPrev) {
+                    androidx.compose.material3.Icon(Icons.Filled.ArrowBack, contentDescription = "Anterior")
+                }
+            }
+            PlainTooltipBox(tooltip = { Text("Siguiente") }) {
+                IconButton(onClick = onNext) {
+                    androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
+                }
+            }
+            PlainTooltipBox(tooltip = { Text("Cancelar") }) {
+                IconButton(onClick = onClose) {
+                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
+                }
             }
         }
     }

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -15,17 +16,22 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.toMutableStateMap
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.toMutableStateMap
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import com.gio.guiasclinicas.data.model.*
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.SearchPart
+import com.gio.guiasclinicas.ui.search.highlightText
 import com.gio.guiasclinicas.ui.components.zoom.ZoomResetHost
 import com.gio.guiasclinicas.ui.components.zoom.resetZoomOnParentVerticalScroll
 import com.gio.guiasclinicas.ui.state.ChapterUiState
@@ -38,10 +44,18 @@ private val ScreenVerticalPadding = 8.dp
 private val ScreenBottomSafePadding = 24.dp    // que no choque con el bottom bar
 
 @Composable
-fun ChapterContentView(state: ChapterUiState) {
+fun ChapterContentView(
+    state: ChapterUiState,
+    searchResults: List<SearchResult> = emptyList(),
+    currentResult: Int = -1
+) {
     when (state) {
         is ChapterUiState.Ready ->
-            ChapterBodyView(sections = state.content.content.sections)
+            ChapterBodyView(
+                sections = state.content.content.sections,
+                searchResults = searchResults,
+                currentResult = currentResult
+            )
 
         is ChapterUiState.Loading ->
             Text(
@@ -67,7 +81,11 @@ fun ChapterContentView(state: ChapterUiState) {
 }
 
 @Composable
-private fun ChapterBodyView(sections: List<ChapterSection>) {
+private fun ChapterBodyView(
+    sections: List<ChapterSection>,
+    searchResults: List<SearchResult>,
+    currentResult: Int
+) {
     val scope = rememberCoroutineScope()
     val expandedMap: SnapshotStateMap<String, Boolean> = rememberSaveable(
         saver = mapSaver<SnapshotStateMap<String, Boolean>>(
@@ -78,6 +96,21 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
         )
     ) {
         mutableStateMapOf<String, Boolean>()
+    }
+
+    val listState = rememberLazyListState()
+    val sectionIndexMap = remember(sections) {
+        sections.mapIndexed { idx, sec ->
+            (sec.id ?: "sec-$idx-${sec::class.simpleName}") to idx
+        }.toMap()
+    }
+    val matchesBySection = remember(searchResults) { searchResults.groupBy { it.sectionKey } }
+
+    LaunchedEffect(currentResult) {
+        val target = searchResults.getOrNull(currentResult) ?: return@LaunchedEffect
+        val index = sectionIndexMap[target.sectionKey] ?: return@LaunchedEffect
+        expandedMap[target.sectionKey] = true
+        listState.animateScrollToItem(index)
     }
 
     ZoomResetHost {
@@ -117,6 +150,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
             Spacer(Modifier.height(DefaultSectionSpacing))
 
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .resetZoomOnParentVerticalScroll(scope),
@@ -128,6 +162,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
                 ) { index, section ->
                     val key = section.id ?: "sec-$index-${section::class.simpleName}"
                     val expanded = expandedMap[key] ?: false
+                    val matches = matchesBySection[key].orEmpty()
 
                     if (index > 0) {
                         val prev = sections[index - 1]
@@ -167,7 +202,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
                             }
                             if (expanded) {
                                 Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                                    RenderSection(section)
+                                    RenderSection(section, matches, currentResult)
                                 }
                             }
                         }
@@ -179,16 +214,25 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
 }
 
 @Composable
-private fun RenderSection(section: ChapterSection) {
+private fun RenderSection(
+    section: ChapterSection,
+    matches: List<SearchResult>,
+    currentIndex: Int
+) {
     when (section) {
         is TextSection -> {
             section.body?.let {
-                Text(text = it, style = MaterialTheme.typography.bodyMedium)
+                val bodyMatches = matches.filter { m -> m.part == SearchPart.BODY }
+                Text(
+                    text = highlightText(it, bodyMatches, currentIndex),
+                    style = MaterialTheme.typography.bodyMedium
+                )
             }
             section.footnote?.let {
                 Spacer(Modifier.height(6.dp))
+                val footMatches = matches.filter { m -> m.part == SearchPart.FOOTNOTE }
                 Text(
-                    text = it,
+                    text = highlightText(it, footMatches, currentIndex),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
@@ -1,0 +1,74 @@
+package com.gio.guiasclinicas.ui.search
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import com.gio.guiasclinicas.data.model.ChapterSection
+import com.gio.guiasclinicas.data.model.TextSection
+import java.text.Normalizer
+
+/** Indicates which part of a section matched the query */
+enum class SearchPart { BODY, FOOTNOTE }
+
+/** Represents one occurrence of the search query */
+data class SearchResult(
+    val sectionKey: String,
+    val part: SearchPart,
+    val start: Int,
+    val length: Int,
+    val index: Int
+)
+
+private fun normalize(text: String): String =
+    Normalizer.normalize(text, Normalizer.Form.NFD)
+        .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
+        .lowercase()
+
+/** Finds all occurrences of [query] in [sections] ignoring case and accents */
+fun searchSections(sections: List<ChapterSection>, query: String): List<SearchResult> {
+    val normQuery = normalize(query)
+    if (normQuery.isBlank()) return emptyList()
+    val results = mutableListOf<SearchResult>()
+    sections.forEachIndexed { index, section ->
+        val key = section.id ?: "sec-$index-${section::class.simpleName}"
+        when (section) {
+            is TextSection -> {
+                section.body?.let { body ->
+                    val normBody = normalize(body)
+                    var start = 0
+                    while (true) {
+                        val idx = normBody.indexOf(normQuery, start)
+                        if (idx < 0) break
+                        results.add(SearchResult(key, SearchPart.BODY, idx, normQuery.length, results.size))
+                        start = idx + normQuery.length
+                    }
+                }
+                section.footnote?.let { foot ->
+                    val normFoot = normalize(foot)
+                    var start = 0
+                    while (true) {
+                        val idx = normFoot.indexOf(normQuery, start)
+                        if (idx < 0) break
+                        results.add(SearchResult(key, SearchPart.FOOTNOTE, idx, normQuery.length, results.size))
+                        start = idx + normQuery.length
+                    }
+                }
+            }
+            else -> Unit
+        }
+    }
+    return results
+}
+
+/** Builds an [AnnotatedString] highlighting [matches]. */
+fun highlightText(text: String, matches: List<SearchResult>, currentIndex: Int): AnnotatedString {
+    if (matches.isEmpty()) return AnnotatedString(text)
+    return buildAnnotatedString {
+        append(text)
+        matches.forEach { m ->
+            val color = if (m.index == currentIndex) Color.Green else Color.Yellow
+            addStyle(SpanStyle(color = color), m.start, m.start + m.length)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement accent- and case-insensitive search utilities
- highlight search results in chapters with current result in green and others in yellow
- add search bar with next/previous/cancel controls and tooltips

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af5fd8ce54832093afbf52d80f0ac7