### PR TITLE
Add basic chapter text search with navigation

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -209,10 +209,14 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                             query = searchQuery,
                             onQueryChange = { searchQuery = it },
                             onNext = {
-                                if (searchResults.isNotEmpty()) currentResult = (currentResult + 1) % searchResults.size
+                                if (searchResults.isNotEmpty()) {
+                                    currentResult = (currentResult + 1) % searchResults.size
+                                }
                             },
                             onPrev = {
-                                if (searchResults.isNotEmpty()) currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                                if (searchResults.isNotEmpty()) {
+                                    currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                                }
                             },
                             onClose = {
                                 searchVisible = false

--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
@@ -19,6 +20,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.FormatSize
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -30,6 +33,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -79,7 +83,9 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
     val chapterState by vm.chapterState.collectAsStateWithLifecycle()
 
     var searchVisible by remember { mutableStateOf(false) }
-    var searchQuery by remember { mutableStateOf("ejemplo") }
+    var searchQuery by remember { mutableStateOf("dolor") }
+    var ignoreCase by remember { mutableStateOf(true) }
+    var ignoreAccents by remember { mutableStateOf(true) }
     val searchResults = remember { mutableStateListOf<SearchResult>() }
     var currentResult by remember { mutableStateOf(0) }
 
@@ -92,11 +98,13 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
         }
     }
 
-    LaunchedEffect(searchQuery, chapterState, searchVisible) {
+    LaunchedEffect(searchQuery, chapterState, searchVisible, ignoreCase, ignoreAccents) {
         if (searchVisible && chapterState is ChapterUiState.Ready) {
             val sections = (chapterState as ChapterUiState.Ready).content.content.sections
             searchResults.clear()
-            searchResults.addAll(searchSections(sections, searchQuery))
+            searchResults.addAll(
+                searchSections(sections, searchQuery, ignoreCase, ignoreAccents)
+            )
             currentResult = 0
         } else {
             searchResults.clear()
@@ -196,22 +204,32 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                 ChapterContentView(state = chapterState, searchResults = searchResults, currentResult = currentResult)
 
                 if (searchVisible) {
-                    ChapterSearchBar(
-                        query = searchQuery,
-                        onQueryChange = { searchQuery = it },
-                        onNext = {
-                            if (searchResults.isNotEmpty()) currentResult = (currentResult + 1) % searchResults.size
-                        },
-                        onPrev = {
-                            if (searchResults.isNotEmpty()) currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
-                        },
-                        onClose = {
-                            searchVisible = false
-                            searchResults.clear()
-                            currentResult = 0
-                        },
-                        modifier = Modifier.align(Alignment.TopCenter)
-                    )
+                    Column(modifier = Modifier.align(Alignment.TopCenter)) {
+                        ChapterSearchBar(
+                            query = searchQuery,
+                            onQueryChange = { searchQuery = it },
+                            onNext = {
+                                if (searchResults.isNotEmpty()) currentResult = (currentResult + 1) % searchResults.size
+                            },
+                            onPrev = {
+                                if (searchResults.isNotEmpty()) currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                            },
+                            onClose = {
+                                searchVisible = false
+                                searchResults.clear()
+                                currentResult = 0
+                            },
+                            ignoreCase = ignoreCase,
+                            onToggleCase = { ignoreCase = !ignoreCase },
+                            ignoreAccents = ignoreAccents,
+                            onToggleAccents = { ignoreAccents = !ignoreAccents }
+                        )
+                        SearchResultsList(
+                            results = searchResults,
+                            current = currentResult,
+                            onResultClick = { idx -> currentResult = idx }
+                        )
+                    }
                 }
             }
         }
@@ -225,6 +243,10 @@ private fun ChapterSearchBar(
     onNext: () -> Unit,
     onPrev: () -> Unit,
     onClose: () -> Unit,
+    ignoreCase: Boolean,
+    onToggleCase: () -> Unit,
+    ignoreAccents: Boolean,
+    onToggleAccents: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(modifier = modifier.fillMaxWidth()) {
@@ -235,6 +257,24 @@ private fun ChapterSearchBar(
                 modifier = Modifier.weight(1f),
                 singleLine = true
             )
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text(if (ignoreCase) "Ignorar mayúsculas" else "Distinguir mayúsculas") },
+                state = rememberTooltipState()
+            ) {
+                IconToggleButton(checked = ignoreCase, onCheckedChange = { onToggleCase() }) {
+                    androidx.compose.material3.Icon(Icons.Filled.FormatSize, contentDescription = "Mayúsculas")
+                }
+            }
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text(if (ignoreAccents) "Ignorar acentos" else "Distinguir acentos") },
+                state = rememberTooltipState()
+            ) {
+                IconToggleButton(checked = ignoreAccents, onCheckedChange = { onToggleAccents() }) {
+                    androidx.compose.material3.Icon(Icons.Filled.Translate, contentDescription = "Acentos")
+                }
+            }
             TooltipBox(
                 positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
                 tooltip = { Text("Anterior") },
@@ -262,6 +302,28 @@ private fun ChapterSearchBar(
                     androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun SearchResultsList(
+    results: List<SearchResult>,
+    current: Int,
+    onResultClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
+        items(results) { res ->
+            val color = if (res.index == current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            Text(
+                text = res.preview,
+                color = color,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onResultClick(res.index) }
+                    .padding(8.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -6,11 +6,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -23,10 +28,20 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +50,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gio.guiasclinicas.ui.components.ClinicalGuidesMenuTopBar
 import com.gio.guiasclinicas.ui.components.ChapterContentView
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.searchSections
+import com.gio.guiasclinicas.ui.state.ChapterUiState
 import com.gio.guiasclinicas.ui.state.GuideDetailUiState
 import com.gio.guiasclinicas.ui.theme.GuiasClinicasTheme
 import com.gio.guiasclinicas.ui.viewmodel.GuidesViewModel
@@ -60,12 +78,29 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
     val detailState by vm.detailState.collectAsStateWithLifecycle()
     val chapterState by vm.chapterState.collectAsStateWithLifecycle()
 
+    var searchVisible by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("ejemplo") }
+    val searchResults = remember { mutableStateListOf<SearchResult>() }
+    var currentResult by remember { mutableStateOf(0) }
+
     // Abre/cierra el drawer según el estado de detalle
     LaunchedEffect(detailState) {
         when (detailState) {
             is GuideDetailUiState.Ready -> drawerState.open()
             GuideDetailUiState.Idle -> drawerState.close()
             else -> Unit
+        }
+    }
+
+    LaunchedEffect(searchQuery, chapterState, searchVisible) {
+        if (searchVisible && chapterState is ChapterUiState.Ready) {
+            val sections = (chapterState as ChapterUiState.Ready).content.content.sections
+            searchResults.clear()
+            searchResults.addAll(searchSections(sections, searchQuery))
+            currentResult = 0
+        } else {
+            searchResults.clear()
+            currentResult = 0
         }
     }
 
@@ -136,7 +171,8 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             bottomBar = {
                 NavigationBar {
                     NavigationBarItem(
-                        selected = false, onClick = {},
+                        selected = searchVisible,
+                        onClick = { searchVisible = !searchVisible },
                         icon = { androidx.compose.material3.Icon(Icons.Filled.Search, contentDescription = "Buscar") }
                     )
                     NavigationBarItem(
@@ -157,7 +193,74 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                 contentAlignment = Alignment.TopStart
             ) {
                 // Renderiza el contenido del capítulo (ready/loading/error/idle)
-                ChapterContentView(state = chapterState)
+                ChapterContentView(state = chapterState, searchResults = searchResults, currentResult = currentResult)
+
+                if (searchVisible) {
+                    ChapterSearchBar(
+                        query = searchQuery,
+                        onQueryChange = { searchQuery = it },
+                        onNext = {
+                            if (searchResults.isNotEmpty()) currentResult = (currentResult + 1) % searchResults.size
+                        },
+                        onPrev = {
+                            if (searchResults.isNotEmpty()) currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                        },
+                        onClose = {
+                            searchVisible = false
+                            searchResults.clear()
+                            currentResult = 0
+                        },
+                        modifier = Modifier.align(Alignment.TopCenter)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onNext: () -> Unit,
+    onPrev: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier = Modifier.weight(1f),
+                singleLine = true
+            )
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text("Anterior") },
+                state = rememberTooltipState()
+            ) {
+                IconButton(onClick = onPrev) {
+                    androidx.compose.material3.Icon(Icons.Filled.ArrowBack, contentDescription = "Anterior")
+                }
+            }
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text("Siguiente") },
+                state = rememberTooltipState()
+            ) {
+                IconButton(onClick = onNext) {
+                    androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
+                }
+            }
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text("Cancelar") },
+                state = rememberTooltipState()
+            ) {
+                IconButton(onClick = onClose) {
+                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
+                }
             }
         }
     }

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
@@ -34,6 +34,9 @@ import androidx.compose.ui.window.Dialog
 import com.gio.guiasclinicas.data.model.TableSection
 import com.gio.guiasclinicas.ui.components.table.SmartBreaks
 import com.gio.guiasclinicas.ui.theme.LocalTableTheme
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.highlightText
+import com.gio.guiasclinicas.ui.search.SearchPart
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -70,7 +73,11 @@ fun ShouldUseBigTable(section: TableSection): Boolean {
  *  celdas con altura uniforme, elipsis + diálogo, paginación y fade derecho.
  * ---------------------------------------------------------------------- */
 @Composable
-fun BigTableSectionView(section: TableSection) {
+fun BigTableSectionView(
+    section: TableSection,
+    matches: List<SearchResult>,
+    currentIndex: Int
+) {
     val theme = LocalTableTheme.current
     val cols = section.columns
     val allRows = section.rows
@@ -255,8 +262,9 @@ fun BigTableSectionView(section: TableSection) {
             // ----------------------------- FOOTNOTE -----------------------------
             section.footnote?.let { note ->
                 Spacer(Modifier.height(8.dp))
+                val footMatches = matches.filter { it.part == SearchPart.FOOTNOTE }
                 Text(
-                    text = note,
+                    text = highlightText(note, footMatches, currentIndex),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -15,17 +16,22 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.toMutableStateMap
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.toMutableStateMap
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import com.gio.guiasclinicas.data.model.*
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.SearchPart
+import com.gio.guiasclinicas.ui.search.highlightText
 import com.gio.guiasclinicas.ui.components.zoom.ZoomResetHost
 import com.gio.guiasclinicas.ui.components.zoom.resetZoomOnParentVerticalScroll
 import com.gio.guiasclinicas.ui.state.ChapterUiState
@@ -38,10 +44,18 @@ private val ScreenVerticalPadding = 8.dp
 private val ScreenBottomSafePadding = 24.dp    // que no choque con el bottom bar
 
 @Composable
-fun ChapterContentView(state: ChapterUiState) {
+fun ChapterContentView(
+    state: ChapterUiState,
+    searchResults: List<SearchResult> = emptyList(),
+    currentResult: Int = -1
+) {
     when (state) {
         is ChapterUiState.Ready ->
-            ChapterBodyView(sections = state.content.content.sections)
+            ChapterBodyView(
+                sections = state.content.content.sections,
+                searchResults = searchResults,
+                currentResult = currentResult
+            )
 
         is ChapterUiState.Loading ->
             Text(
@@ -67,7 +81,11 @@ fun ChapterContentView(state: ChapterUiState) {
 }
 
 @Composable
-private fun ChapterBodyView(sections: List<ChapterSection>) {
+private fun ChapterBodyView(
+    sections: List<ChapterSection>,
+    searchResults: List<SearchResult>,
+    currentResult: Int
+) {
     val scope = rememberCoroutineScope()
     val expandedMap: SnapshotStateMap<String, Boolean> = rememberSaveable(
         saver = mapSaver<SnapshotStateMap<String, Boolean>>(
@@ -78,6 +96,21 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
         )
     ) {
         mutableStateMapOf<String, Boolean>()
+    }
+
+    val listState = rememberLazyListState()
+    val sectionIndexMap = remember(sections) {
+        sections.mapIndexed { idx, sec ->
+            (sec.id ?: "sec-$idx-${sec::class.simpleName}") to idx
+        }.toMap()
+    }
+    val matchesBySection = remember(searchResults) { searchResults.groupBy { it.sectionKey } }
+
+    LaunchedEffect(currentResult) {
+        val target = searchResults.getOrNull(currentResult) ?: return@LaunchedEffect
+        val index = sectionIndexMap[target.sectionKey] ?: return@LaunchedEffect
+        expandedMap[target.sectionKey] = true
+        listState.animateScrollToItem(index)
     }
 
     ZoomResetHost {
@@ -117,6 +150,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
             Spacer(Modifier.height(DefaultSectionSpacing))
 
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .resetZoomOnParentVerticalScroll(scope),
@@ -128,6 +162,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
                 ) { index, section ->
                     val key = section.id ?: "sec-$index-${section::class.simpleName}"
                     val expanded = expandedMap[key] ?: false
+                    val matches = matchesBySection[key].orEmpty()
 
                     if (index > 0) {
                         val prev = sections[index - 1]
@@ -167,7 +202,7 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
                             }
                             if (expanded) {
                                 Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                                    RenderSection(section)
+                                    RenderSection(section, matches, currentResult)
                                 }
                             }
                         }
@@ -179,16 +214,25 @@ private fun ChapterBodyView(sections: List<ChapterSection>) {
 }
 
 @Composable
-private fun RenderSection(section: ChapterSection) {
+private fun RenderSection(
+    section: ChapterSection,
+    matches: List<SearchResult>,
+    currentIndex: Int
+) {
     when (section) {
         is TextSection -> {
             section.body?.let {
-                Text(text = it, style = MaterialTheme.typography.bodyMedium)
+                val bodyMatches = matches.filter { m -> m.part == SearchPart.BODY }
+                Text(
+                    text = highlightText(it, bodyMatches, currentIndex),
+                    style = MaterialTheme.typography.bodyMedium
+                )
             }
             section.footnote?.let {
                 Spacer(Modifier.height(6.dp))
+                val footMatches = matches.filter { m -> m.part == SearchPart.FOOTNOTE }
                 Text(
-                    text = it,
+                    text = highlightText(it, footMatches, currentIndex),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ChapterContentView.kt
@@ -180,10 +180,12 @@ private fun ChapterBodyView(
                         onClick = { expandedMap[key] = !expanded }
                     ) {
                         Column {
-                            val title = section.title
+                            val rawTitle = section.title
                                 ?: (section as? TextSection)?.heading
                                 ?: (section as? ImageSection)?.caption
                                 ?: "Sección ${index + 1}"
+                            val headingMatches = matches.filter { it.part == SearchPart.HEADING || it.part == SearchPart.CAPTION }
+                            val titleText = highlightText(rawTitle, headingMatches, currentResult)
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -191,7 +193,7 @@ private fun ChapterBodyView(
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Text(
-                                    text = title,
+                                    text = titleText,
                                     style = MaterialTheme.typography.titleMedium,
                                     modifier = Modifier.weight(1f)
                                 )
@@ -237,15 +239,20 @@ private fun RenderSection(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            // Sin Spacer final: lo gestiona ChapterBodyView para el ritmo visual
         }
 
         is TableSection -> {
-            TableSectionView(section)  // renderer universal de tablas
+            TableSectionView(section = section, matches = matches, currentIndex = currentIndex)
         }
 
         is ImageSection -> {
-            ImageSectionView(section)  // usa el contenedor zoom/pan y el tema de imagen
+            val captionMatches = matches.filter { it.part == SearchPart.CAPTION }
+            val footMatches = matches.filter { it.part == SearchPart.FOOTNOTE }
+            ImageSectionView(
+                section = section,
+                captionText = section.caption?.let { highlightText(it, captionMatches, currentIndex) },
+                footnoteText = section.footnote?.let { highlightText(it, footMatches, currentIndex) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/GuideTable.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/GuideTable.kt
@@ -32,6 +32,9 @@ import com.gio.guiasclinicas.ui.theme.RecommendationTableTheme
 import java.text.Normalizer
 import com.gio.guiasclinicas.ui.components.BigTableSectionView
 import com.gio.guiasclinicas.ui.components.ShouldUseBigTable
+import com.gio.guiasclinicas.ui.search.SearchResult
+import com.gio.guiasclinicas.ui.search.highlightText
+import com.gio.guiasclinicas.ui.search.SearchPart
 import kotlin.math.max
 
 
@@ -39,18 +42,20 @@ import kotlin.math.max
 // Selector de renderer según variante
 // ======================================================
 @Composable
-fun TableSectionView(section: TableSection) {
+fun TableSectionView(
+    section: TableSection,
+    matches: List<SearchResult> = emptyList(),
+    currentIndex: Int = -1
+) {
     if (section.variant.isRecommendationVariant()) {
-        // Las tablas de recomendaciones mantienen su renderer propio
         RecommendationTableTheme {
             RecommendationTableView(section)
         }
     } else {
-        // Para el resto, usar el renderer Pro solo si la tabla es ancha y densa
         if (ShouldUseBigTable(section)) {
-            BigTableSectionView(section)
+            BigTableSectionView(section, matches, currentIndex)
         } else {
-            StandardTableSectionView(section)
+            StandardTableSectionView(section, matches, currentIndex)
         }
     }
 }
@@ -72,7 +77,11 @@ private fun String?.isRecommendationVariant(): Boolean {
 // ======================================================
 @Suppress("BoxWithConstraintsScope")
 @Composable
-private fun StandardTableSectionView(section: TableSection) {
+private fun StandardTableSectionView(
+    section: TableSection,
+    matches: List<SearchResult>,
+    currentIndex: Int
+) {
     val cols = section.columns
     val rows = section.rows
     val theme = LocalTableTheme.current
@@ -254,8 +263,9 @@ private fun StandardTableSectionView(section: TableSection) {
 
         section.footnote?.let { note ->
             Spacer(Modifier.height(8.dp))
+            val footMatches = matches.filter { it.part == SearchPart.FOOTNOTE }
             Text(
-                text = note,
+                text = highlightText(note, footMatches, currentIndex),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/ImageSectionView.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/ImageSectionView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.gio.guiasclinicas.data.model.ImageSection
@@ -24,11 +25,15 @@ import kotlinx.coroutines.withContext
 import kotlin.math.max
 
 @Composable
-fun ImageSectionView(section: ImageSection) {
+fun ImageSectionView(
+    section: ImageSection,
+    captionText: AnnotatedString? = null,
+    footnoteText: AnnotatedString? = null
+) {
     val ctx = LocalContext.current
     val density = LocalDensity.current
     val spec = LocalImageTheme.current
-    val caption = section.caption?.takeIf { it.isNotBlank() }
+    val caption = captionText ?: section.caption?.takeIf { it.isNotBlank() }?.let { AnnotatedString(it) }
     val assetPath = normalizeAssetPath(section.path)
 
     Column(Modifier.fillMaxWidth()) {
@@ -92,6 +97,16 @@ fun ImageSectionView(section: ImageSection) {
             Spacer(Modifier.height(spec.captionSpacingDp.dp))
             Text(
                 text = caption,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Start
+            )
+        }
+
+        footnoteText?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = it,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Start

--- a/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
@@ -1,0 +1,74 @@
+package com.gio.guiasclinicas.ui.search
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import com.gio.guiasclinicas.data.model.ChapterSection
+import com.gio.guiasclinicas.data.model.TextSection
+import java.text.Normalizer
+
+/** Indicates which part of a section matched the query */
+enum class SearchPart { BODY, FOOTNOTE }
+
+/** Represents one occurrence of the search query */
+data class SearchResult(
+    val sectionKey: String,
+    val part: SearchPart,
+    val start: Int,
+    val length: Int,
+    val index: Int
+)
+
+private fun normalize(text: String): String =
+    Normalizer.normalize(text, Normalizer.Form.NFD)
+        .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
+        .lowercase()
+
+/** Finds all occurrences of [query] in [sections] ignoring case and accents */
+fun searchSections(sections: List<ChapterSection>, query: String): List<SearchResult> {
+    val normQuery = normalize(query)
+    if (normQuery.isBlank()) return emptyList()
+    val results = mutableListOf<SearchResult>()
+    sections.forEachIndexed { index, section ->
+        val key = section.id ?: "sec-$index-${section::class.simpleName}"
+        when (section) {
+            is TextSection -> {
+                section.body?.let { body ->
+                    val normBody = normalize(body)
+                    var start = 0
+                    while (true) {
+                        val idx = normBody.indexOf(normQuery, start)
+                        if (idx < 0) break
+                        results.add(SearchResult(key, SearchPart.BODY, idx, normQuery.length, results.size))
+                        start = idx + normQuery.length
+                    }
+                }
+                section.footnote?.let { foot ->
+                    val normFoot = normalize(foot)
+                    var start = 0
+                    while (true) {
+                        val idx = normFoot.indexOf(normQuery, start)
+                        if (idx < 0) break
+                        results.add(SearchResult(key, SearchPart.FOOTNOTE, idx, normQuery.length, results.size))
+                        start = idx + normQuery.length
+                    }
+                }
+            }
+            else -> Unit
+        }
+    }
+    return results
+}
+
+/** Builds an [AnnotatedString] highlighting [matches]. */
+fun highlightText(text: String, matches: List<SearchResult>, currentIndex: Int): AnnotatedString {
+    if (matches.isEmpty()) return AnnotatedString(text)
+    return buildAnnotatedString {
+        append(text)
+        matches.forEach { m ->
+            val color = if (m.index == currentIndex) Color.Green else Color.Yellow
+            addStyle(SpanStyle(color = color), m.start, m.start + m.length)
+        }
+    }
+}

--- a/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/search/SearchUtils.kt
@@ -5,11 +5,15 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import com.gio.guiasclinicas.data.model.ChapterSection
+import com.gio.guiasclinicas.data.model.ImageSection
+import com.gio.guiasclinicas.data.model.TableSection
 import com.gio.guiasclinicas.data.model.TextSection
 import java.text.Normalizer
+import kotlin.math.max
+import kotlin.math.min
 
 /** Indicates which part of a section matched the query */
-enum class SearchPart { BODY, FOOTNOTE }
+enum class SearchPart { HEADING, BODY, FOOTNOTE, CAPTION, ALT, CELL }
 
 /** Represents one occurrence of the search query */
 data class SearchResult(
@@ -17,45 +21,84 @@ data class SearchResult(
     val part: SearchPart,
     val start: Int,
     val length: Int,
-    val index: Int
+    val index: Int,
+    val preview: String,
+    val row: Int? = null,
+    val cellKey: String? = null
 )
 
-private fun normalize(text: String): String =
-    Normalizer.normalize(text, Normalizer.Form.NFD)
-        .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
-        .lowercase()
+private fun normalize(text: String, ignoreCase: Boolean, ignoreAccents: Boolean): String {
+    var result = text
+    if (ignoreAccents) {
+        result = Normalizer.normalize(result, Normalizer.Form.NFD)
+            .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
+    }
+    return if (ignoreCase) result.lowercase() else result
+}
 
-/** Finds all occurrences of [query] in [sections] ignoring case and accents */
-fun searchSections(sections: List<ChapterSection>, query: String): List<SearchResult> {
-    val normQuery = normalize(query)
+private fun String.preview(start: Int, len: Int, radius: Int = 20): String {
+    val from = max(0, start - radius)
+    val to = min(this.length, start + len + radius)
+    return this.substring(from, to)
+}
+
+/** Finds all occurrences of [query] in [sections] with configurable rules */
+fun searchSections(
+    sections: List<ChapterSection>,
+    query: String,
+    ignoreCase: Boolean = true,
+    ignoreAccents: Boolean = true
+): List<SearchResult> {
+    val normQuery = normalize(query, ignoreCase, ignoreAccents)
     if (normQuery.isBlank()) return emptyList()
     val results = mutableListOf<SearchResult>()
     sections.forEachIndexed { index, section ->
         val key = section.id ?: "sec-$index-${section::class.simpleName}"
+        fun scan(text: String?, part: SearchPart, row: Int? = null, cellKey: String? = null) {
+            if (text.isNullOrBlank()) return
+            val normText = normalize(text, ignoreCase, ignoreAccents)
+            var start = 0
+            while (true) {
+                val idx = normText.indexOf(normQuery, start)
+                if (idx < 0) break
+                val preview = text.preview(idx, normQuery.length)
+                results.add(
+                    SearchResult(
+                        sectionKey = key,
+                        part = part,
+                        start = idx,
+                        length = normQuery.length,
+                        index = results.size,
+                        preview = preview,
+                        row = row,
+                        cellKey = cellKey
+                    )
+                )
+                start = idx + normQuery.length
+            }
+        }
+
         when (section) {
             is TextSection -> {
-                section.body?.let { body ->
-                    val normBody = normalize(body)
-                    var start = 0
-                    while (true) {
-                        val idx = normBody.indexOf(normQuery, start)
-                        if (idx < 0) break
-                        results.add(SearchResult(key, SearchPart.BODY, idx, normQuery.length, results.size))
-                        start = idx + normQuery.length
-                    }
-                }
-                section.footnote?.let { foot ->
-                    val normFoot = normalize(foot)
-                    var start = 0
-                    while (true) {
-                        val idx = normFoot.indexOf(normQuery, start)
-                        if (idx < 0) break
-                        results.add(SearchResult(key, SearchPart.FOOTNOTE, idx, normQuery.length, results.size))
-                        start = idx + normQuery.length
+                scan(section.heading, SearchPart.HEADING)
+                scan(section.body, SearchPart.BODY)
+                scan(section.footnote, SearchPart.FOOTNOTE)
+            }
+
+            is ImageSection -> {
+                scan(section.caption, SearchPart.CAPTION)
+                scan(section.alt, SearchPart.ALT)
+                scan(section.footnote, SearchPart.FOOTNOTE)
+            }
+
+            is TableSection -> {
+                section.footnote?.let { scan(it, SearchPart.FOOTNOTE) }
+                section.rows.forEachIndexed { rIdx, row ->
+                    row.cells.forEach { (cellK, value) ->
+                        scan(value, SearchPart.CELL, rIdx, cellK)
                     }
                 }
             }
-            else -> Unit
         }
     }
     return results


### PR DESCRIPTION
## Summary
- implement accent- and case-insensitive search utilities
- highlight search results in chapters with current result in green and others in yellow
- add search bar with next/previous/cancel controls and tooltips
- replace removed `PlainTooltipBox` with `TooltipBox` for proper tooltips

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68af5fd8ce54832093afbf52d80f0ac7