### PR TITLE
Add history and clear actions to search bar

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -5,8 +5,8 @@ package com.gio.guiasclinicas
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,7 +18,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.FormatSize
@@ -30,15 +32,20 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationDrawerItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.material3.SheetValue
 
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
@@ -91,6 +98,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
 
     val searchResults = remember { mutableStateListOf<SearchResult>() }
     var currentResult by remember { mutableStateOf(0) }
+    val searchHistory = remember { mutableStateListOf<String>() }
 
     // Abre/cierra el drawer según el estado de detalle
     LaunchedEffect(detailState) {
@@ -165,7 +173,30 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             }
         }
     ) {
-        Scaffold(
+        val bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            skipHiddenState = false
+        )
+        val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState)
+
+        LaunchedEffect(searchVisible, searchResults.size) {
+            if (searchVisible && searchResults.isNotEmpty()) {
+                bottomSheetState.partialExpand()
+            } else {
+                bottomSheetState.hide()
+            }
+        }
+
+        BottomSheetScaffold(
+            scaffoldState = scaffoldState,
+            sheetPeekHeight = 56.dp,
+            sheetContent = {
+                SearchResultsList(
+                    results = searchResults,
+                    current = currentResult,
+                    onResultClick = { idx -> currentResult = idx }
+                )
+            },
             topBar = {
                 // Usa el MISMO ViewModel que arriba
                 ClinicalGuidesMenuTopBar(
@@ -207,6 +238,10 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                     ChapterSearchBar(
                         query = searchQuery,
                         onQueryChange = { searchQuery = it },
+                        history = searchHistory,
+                        onAddHistory = { q ->
+                            if (!searchHistory.contains(q)) searchHistory.add(0, q)
+                        },
                         onNext = {
                             if (searchResults.isNotEmpty()) {
                                 currentResult = (currentResult + 1) % searchResults.size
@@ -227,13 +262,6 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                         ignoreAccents = ignoreAccents,
                         onToggleAccents = { ignoreAccents = !ignoreAccents }
                     )
-                    Surface {
-                        SearchResultsList(
-                            results = searchResults,
-                            current = currentResult,
-                            onResultClick = { idx -> currentResult = idx }
-                        )
-                    }
                 }
 
                 // Renderiza el contenido del capítulo (ready/loading/error/idle)
@@ -251,6 +279,8 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
 private fun ChapterSearchBar(
     query: String,
     onQueryChange: (String) -> Unit,
+    history: List<String>,
+    onAddHistory: (String) -> Unit,
     onNext: () -> Unit,
     onPrev: () -> Unit,
     onClose: () -> Unit,
@@ -261,12 +291,39 @@ private fun ChapterSearchBar(
     modifier: Modifier = Modifier
 ) {
     Surface(modifier = modifier.fillMaxWidth()) {
+        var historyExpanded by remember { mutableStateOf(false) }
         Row(verticalAlignment = Alignment.CenterVertically) {
+            Box {
+                IconButton(onClick = {
+                    if (query.isNotBlank()) onAddHistory(query)
+                    historyExpanded = !historyExpanded
+                }) {
+                    androidx.compose.material3.Icon(Icons.Filled.History, contentDescription = "Historial")
+                }
+                DropdownMenu(expanded = historyExpanded, onDismissRequest = { historyExpanded = false }) {
+                    history.forEach { past ->
+                        DropdownMenuItem(
+                            text = { Text(past) },
+                            onClick = {
+                                onQueryChange(past)
+                                historyExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
             TextField(
                 value = query,
                 onValueChange = onQueryChange,
                 modifier = Modifier.weight(1f),
-                singleLine = true
+                singleLine = true,
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            androidx.compose.material3.Icon(Icons.Filled.Clear, contentDescription = "Borrar")
+                        }
+                    }
+                }
             )
             TooltipBox(
                 positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),


### PR DESCRIPTION
## Summary
- add history dropdown and clear icon to chapter search bar
- track and reuse past search queries
- present search results in a collapsible bottom sheet

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68af869313788320be015959b543735b