### PR TITLE
Add history and clear actions to search bar

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -5,8 +5,8 @@ package com.gio.guiasclinicas
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,28 +17,29 @@ import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationDrawerItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.material3.SheetValue
 
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
@@ -84,13 +85,13 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
     val detailState by vm.detailState.collectAsStateWithLifecycle()
     val chapterState by vm.chapterState.collectAsStateWithLifecycle()
 
-    var searchVisible by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
     var ignoreCase by remember { mutableStateOf(true) }
     var ignoreAccents by remember { mutableStateOf(true) }
 
     val searchResults = remember { mutableStateListOf<SearchResult>() }
     var currentResult by remember { mutableStateOf(0) }
+    val searchHistory = remember { mutableStateListOf<String>() }
 
     // Abre/cierra el drawer según el estado de detalle
     LaunchedEffect(detailState) {
@@ -101,8 +102,8 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
         }
     }
 
-    LaunchedEffect(searchQuery, chapterState, searchVisible, ignoreCase, ignoreAccents) {
-        if (searchVisible && chapterState is ChapterUiState.Ready) {
+    LaunchedEffect(searchQuery, chapterState, ignoreCase, ignoreAccents) {
+        if (chapterState is ChapterUiState.Ready && searchQuery.isNotBlank()) {
             val sections = (chapterState as ChapterUiState.Ready).content.content.sections
             searchResults.clear()
             searchResults.addAll(
@@ -165,9 +166,31 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             }
         }
     ) {
-        Scaffold(
+        val bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            skipHiddenState = false
+        )
+        val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState)
+
+        LaunchedEffect(searchResults.size) {
+            if (searchResults.isNotEmpty()) {
+                bottomSheetState.partialExpand()
+            } else {
+                bottomSheetState.hide()
+            }
+        }
+
+        BottomSheetScaffold(
+            scaffoldState = scaffoldState,
+            sheetPeekHeight = 56.dp,
+            sheetContent = {
+                SearchResultsList(
+                    results = searchResults,
+                    current = currentResult,
+                    onResultClick = { idx -> currentResult = idx }
+                )
+            },
             topBar = {
-                // Usa el MISMO ViewModel que arriba
                 ClinicalGuidesMenuTopBar(
                     vm = vm,
                     onGuideSelected = { slug -> vm.selectGuide(slug) },
@@ -179,23 +202,6 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                         }
                     }
                 )
-            },
-            bottomBar = {
-                NavigationBar {
-                    NavigationBarItem(
-                        selected = searchVisible,
-                        onClick = { searchVisible = !searchVisible },
-                        icon = { androidx.compose.material3.Icon(Icons.Filled.Search, contentDescription = "Buscar") }
-                    )
-                    NavigationBarItem(
-                        selected = false, onClick = {},
-                        icon = { androidx.compose.material3.Icon(Icons.Filled.Favorite, contentDescription = "Favoritos") }
-                    )
-                    NavigationBarItem(
-                        selected = false, onClick = {},
-                        icon = { androidx.compose.material3.Icon(Icons.Filled.Settings, contentDescription = "Ajustes") }
-                    )
-                }
             }
         ) { innerPadding ->
             Column(
@@ -203,40 +209,29 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                     .fillMaxSize()
                     .padding(innerPadding)
             ) {
-                if (searchVisible) {
-                    ChapterSearchBar(
-                        query = searchQuery,
-                        onQueryChange = { searchQuery = it },
-                        onNext = {
-                            if (searchResults.isNotEmpty()) {
-                                currentResult = (currentResult + 1) % searchResults.size
-                            }
-                        },
-                        onPrev = {
-                            if (searchResults.isNotEmpty()) {
-                                currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
-                            }
-                        },
-                        onClose = {
-                            searchVisible = false
-                            searchResults.clear()
-                            currentResult = 0
-                        },
-                        ignoreCase = ignoreCase,
-                        onToggleCase = { ignoreCase = !ignoreCase },
-                        ignoreAccents = ignoreAccents,
-                        onToggleAccents = { ignoreAccents = !ignoreAccents }
-                    )
-                    Surface {
-                        SearchResultsList(
-                            results = searchResults,
-                            current = currentResult,
-                            onResultClick = { idx -> currentResult = idx }
-                        )
-                    }
-                }
+                ChapterSearchBar(
+                    query = searchQuery,
+                    onQueryChange = { searchQuery = it },
+                    history = searchHistory,
+                    onAddHistory = { q ->
+                        if (!searchHistory.contains(q)) searchHistory.add(0, q)
+                    },
+                    onNext = {
+                        if (searchResults.isNotEmpty()) {
+                            currentResult = (currentResult + 1) % searchResults.size
+                        }
+                    },
+                    onPrev = {
+                        if (searchResults.isNotEmpty()) {
+                            currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                        }
+                    },
+                    ignoreCase = ignoreCase,
+                    onToggleCase = { ignoreCase = !ignoreCase },
+                    ignoreAccents = ignoreAccents,
+                    onToggleAccents = { ignoreAccents = !ignoreAccents }
+                )
 
-                // Renderiza el contenido del capítulo (ready/loading/error/idle)
                 ChapterContentView(
                     state = chapterState,
                     searchResults = searchResults,
@@ -251,9 +246,10 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
 private fun ChapterSearchBar(
     query: String,
     onQueryChange: (String) -> Unit,
+    history: List<String>,
+    onAddHistory: (String) -> Unit,
     onNext: () -> Unit,
     onPrev: () -> Unit,
-    onClose: () -> Unit,
     ignoreCase: Boolean,
     onToggleCase: () -> Unit,
     ignoreAccents: Boolean,
@@ -261,12 +257,39 @@ private fun ChapterSearchBar(
     modifier: Modifier = Modifier
 ) {
     Surface(modifier = modifier.fillMaxWidth()) {
+        var historyExpanded by remember { mutableStateOf(false) }
         Row(verticalAlignment = Alignment.CenterVertically) {
+            Box {
+                IconButton(onClick = {
+                    if (query.isNotBlank()) onAddHistory(query)
+                    historyExpanded = !historyExpanded
+                }) {
+                    androidx.compose.material3.Icon(Icons.Filled.History, contentDescription = "Historial")
+                }
+                DropdownMenu(expanded = historyExpanded, onDismissRequest = { historyExpanded = false }) {
+                    history.forEach { past ->
+                        DropdownMenuItem(
+                            text = { Text(past) },
+                            onClick = {
+                                onQueryChange(past)
+                                historyExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
             TextField(
                 value = query,
                 onValueChange = onQueryChange,
                 modifier = Modifier.weight(1f),
-                singleLine = true
+                singleLine = true,
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            androidx.compose.material3.Icon(Icons.Filled.Clear, contentDescription = "Borrar")
+                        }
+                    }
+                }
             )
             TooltipBox(
                 positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
@@ -303,15 +326,6 @@ private fun ChapterSearchBar(
                 IconButton(onClick = onNext) {
                     androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
 
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Cancelar") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onClose) {
-                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add search history dropdown and clear icon to chapter search bar
- automatically expand a collapsible bottom sheet to show matches

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68af869313788320be015959b543735b