### PR TITLE
Fix Compose references and cleanup search components

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
@@ -194,7 +194,7 @@ fun BigTableSectionView(
             pageRows.forEachIndexed { rIndex, r ->
 
                 // Repetimos encabezado cada N filas (barato, sin segundo scroll)
-                if (index > 0 && index % REPEAT_HEADER_EVERY == 0) {
+                if (rIndex > 0 && rIndex % REPEAT_HEADER_EVERY == 0) {
                     TableHeaderRow(
                         cols = cols,
                         colWidthsDp = colWidthsDp,


### PR DESCRIPTION
## Summary
- import missing Material3 APIs and remove duplicated search components
- correct search bar alignment and bottom sheet usage
- fix BigTable pagination header repetition index
- host bottom navigation in a top-level Scaffold wrapping the bottom sheet

## Testing
- `./gradlew app:compileDebugKotlin` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af951dd0d883208a87007882d3c7e5