### PR TITLE
Fix Compose references and cleanup search components

### DIFF
--- a/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/MainActivity.kt
@@ -5,13 +5,12 @@ package com.gio.guiasclinicas
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
@@ -19,28 +18,37 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 
 import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.Translate
+import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconToggleButton
-
-import androidx.compose.material3.Surface
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberTooltipState
-
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberDrawerState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
@@ -90,6 +98,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
     var ignoreAccents by remember { mutableStateOf(true) }
     val searchResults = remember { mutableStateListOf<SearchResult>() }
     var currentResult by remember { mutableStateOf(0) }
+    val searchHistory = remember { mutableStateListOf<String>() }
 
 
     // Abre/cierra el drawer según el estado de detalle
@@ -109,6 +118,13 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             searchResults.addAll(
                 searchSections(sections, searchQuery, ignoreCase, ignoreAccents)
             )
+
+            if (searchQuery.isNotBlank() &&
+                searchResults.isNotEmpty() &&
+                searchQuery !in searchHistory
+            ) {
+                searchHistory.add(0, searchQuery)
+            }
 
             currentResult = 0
         } else {
@@ -181,16 +197,7 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
             }
         }
 
-        BottomSheetScaffold(
-            scaffoldState = scaffoldState,
-            sheetPeekHeight = 56.dp,
-            sheetContent = {
-                SearchResultsList(
-                    results = searchResults,
-                    current = currentResult,
-                    onResultClick = { idx -> currentResult = idx }
-                )
-            },
+        Scaffold(
             topBar = {
                 ClinicalGuidesMenuTopBar(
                     vm = vm,
@@ -228,48 +235,57 @@ fun GuidesApp(vm: GuidesViewModel = viewModel()) {
                         alwaysShowLabel = false
                     )
                 }
-
             }
-        ) { innerPadding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                // Renderiza el contenido del capítulo (ready/loading/error/idle)
-                ChapterContentView(state = chapterState, searchResults = searchResults, currentResult = currentResult)
+        ) { outerPadding ->
+            BottomSheetScaffold(
+                scaffoldState = scaffoldState,
+                sheetPeekHeight = 56.dp,
+                sheetContent = {
+                    SearchResultsList(
+                        results = searchResults,
+                        current = currentResult,
+                        onResultClick = { idx -> currentResult = idx }
+                    )
+                }
+            ) { innerPadding ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(outerPadding)
+                        .padding(innerPadding)
+                ) {
+                    // Renderiza el contenido del capítulo (ready/loading/error/idle)
+                    ChapterContentView(state = chapterState, searchResults = searchResults, currentResult = currentResult)
 
-                if (searchVisible) {
-                    Column(modifier = Modifier.align(Alignment.TopCenter)) {
-                        ChapterSearchBar(
-                            query = searchQuery,
-                            onQueryChange = { searchQuery = it },
-                            onNext = {
-                                if (searchResults.isNotEmpty()) {
-                                    currentResult = (currentResult + 1) % searchResults.size
-                                }
-                            },
-                            onPrev = {
-                                if (searchResults.isNotEmpty()) {
-                                    currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
-                                }
-                            },
-                            onClose = {
-                                searchVisible = false
-                                searchResults.clear()
-                                currentResult = 0
-                            },
-                            ignoreCase = ignoreCase,
-                            onToggleCase = { ignoreCase = !ignoreCase },
-                            ignoreAccents = ignoreAccents,
-                            onToggleAccents = { ignoreAccents = !ignoreAccents }
-                        )
-                        SearchResultsList(
-                            results = searchResults,
-                            current = currentResult,
-                            onResultClick = { idx -> currentResult = idx },
-                            modifier = Modifier.heightIn(max = 200.dp)
-                        )
+                    if (searchVisible) {
+                        Column(modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                            ChapterSearchBar(
+                                query = searchQuery,
+                                onQueryChange = { searchQuery = it },
+                                onNext = {
+                                    if (searchResults.isNotEmpty()) {
+                                        currentResult = (currentResult + 1) % searchResults.size
+                                    }
+                                },
+                                onPrev = {
+                                    if (searchResults.isNotEmpty()) {
+                                        currentResult = (currentResult - 1 + searchResults.size) % searchResults.size
+                                    }
+                                },
+                                onClose = {
+                                    searchVisible = false
+                                    searchResults.clear()
+                                    currentResult = 0
+                                },
+                                ignoreCase = ignoreCase,
+                                onToggleCase = { ignoreCase = !ignoreCase },
+                                ignoreAccents = ignoreAccents,
+                                onToggleAccents = { ignoreAccents = !ignoreAccents },
+                                history = searchHistory,
+                                onHistorySelected = { searchQuery = it },
+                                onRemoveHistory = { searchHistory.remove(it) }
+                            )
+                        }
                     }
                 }
             }
@@ -288,212 +304,30 @@ private fun ChapterSearchBar(
     onToggleCase: () -> Unit,
     ignoreAccents: Boolean,
     onToggleAccents: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Surface(modifier = modifier.fillMaxWidth()) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            TextField(
-                value = query,
-                onValueChange = onQueryChange,
-                modifier = Modifier.weight(1f),
-                singleLine = true
-            )
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text(if (ignoreCase) "Ignorar mayúsculas" else "Distinguir mayúsculas") },
-                state = rememberTooltipState()
-            ) {
-                IconToggleButton(checked = ignoreCase, onCheckedChange = { onToggleCase() }) {
-                    androidx.compose.material3.Icon(Icons.Filled.FormatSize, contentDescription = "Mayúsculas")
-                }
-
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text(if (ignoreAccents) "Ignorar acentos" else "Distinguir acentos") },
-                state = rememberTooltipState()
-            ) {
-                IconToggleButton(checked = ignoreAccents, onCheckedChange = { onToggleAccents() }) {
-                    androidx.compose.material3.Icon(Icons.Filled.Translate, contentDescription = "Acentos")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Anterior") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onPrev) {
-                    androidx.compose.material3.Icon(Icons.Filled.ArrowBack, contentDescription = "Anterior")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Siguiente") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onNext) {
-                    androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Cancelar") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onClose) {
-                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SearchResultsList(
-    results: List<SearchResult>,
-    current: Int,
-    onResultClick: (Int) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
-        items(results) { res ->
-            val color = if (res.index == current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-            Text(
-                text = res.preview,
-                color = color,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onResultClick(res.index) }
-                    .padding(8.dp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun ChapterSearchBar(
-    query: String,
-    onQueryChange: (String) -> Unit,
-    onNext: () -> Unit,
-    onPrev: () -> Unit,
-    onClose: () -> Unit,
-    ignoreCase: Boolean,
-    onToggleCase: () -> Unit,
-    ignoreAccents: Boolean,
-    onToggleAccents: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Surface(modifier = modifier.fillMaxWidth()) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            TextField(
-                value = query,
-                onValueChange = onQueryChange,
-                modifier = Modifier.weight(1f),
-                singleLine = true
-            )
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text(if (ignoreCase) "Ignorar mayúsculas" else "Distinguir mayúsculas") },
-                state = rememberTooltipState()
-            ) {
-                IconToggleButton(checked = ignoreCase, onCheckedChange = { onToggleCase() }) {
-                    androidx.compose.material3.Icon(Icons.Filled.FormatSize, contentDescription = "Mayúsculas")
-                }
-
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text(if (ignoreAccents) "Ignorar acentos" else "Distinguir acentos") },
-                state = rememberTooltipState()
-            ) {
-                IconToggleButton(checked = ignoreAccents, onCheckedChange = { onToggleAccents() }) {
-                    androidx.compose.material3.Icon(Icons.Filled.Translate, contentDescription = "Acentos")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Anterior") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onPrev) {
-                    androidx.compose.material3.Icon(Icons.Filled.ArrowBack, contentDescription = "Anterior")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Siguiente") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onNext) {
-                    androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
-                }
-            }
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                tooltip = { Text("Cancelar") },
-                state = rememberTooltipState()
-            ) {
-                IconButton(onClick = onClose) {
-                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SearchResultsList(
-    results: List<SearchResult>,
-    current: Int,
-    onResultClick: (Int) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
-        items(results) { res ->
-            val color = if (res.index == current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-            Text(
-                text = res.preview,
-                color = color,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onResultClick(res.index) }
-                    .padding(8.dp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun ChapterSearchBar(
-    query: String,
-    onQueryChange: (String) -> Unit,
     history: List<String>,
-    onAddHistory: (String) -> Unit,
-    onNext: () -> Unit,
-    onPrev: () -> Unit,
-    ignoreCase: Boolean,
-    onToggleCase: () -> Unit,
-    ignoreAccents: Boolean,
-    onToggleAccents: () -> Unit,
+    onHistorySelected: (String) -> Unit,
+    onRemoveHistory: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(modifier = modifier.fillMaxWidth()) {
-        var historyExpanded by remember { mutableStateOf(false) }
         Row(verticalAlignment = Alignment.CenterVertically) {
+            var historyExpanded by remember { mutableStateOf(false) }
             Box {
-                IconButton(onClick = {
-                    if (query.isNotBlank()) onAddHistory(query)
-                    historyExpanded = !historyExpanded
-                }) {
+                IconButton(onClick = { historyExpanded = !historyExpanded }) {
                     androidx.compose.material3.Icon(Icons.Filled.History, contentDescription = "Historial")
                 }
                 DropdownMenu(expanded = historyExpanded, onDismissRequest = { historyExpanded = false }) {
-                    history.forEach { past ->
+                    history.forEach { item ->
                         DropdownMenuItem(
-                            text = { Text(past) },
+                            text = { Text(item) },
                             onClick = {
-                                onQueryChange(past)
+                                onHistorySelected(item)
                                 historyExpanded = false
+                            },
+                            leadingIcon = {
+                                IconButton(onClick = { onRemoveHistory(item) }) {
+                                    androidx.compose.material3.Icon(Icons.Filled.Clear, contentDescription = "Eliminar")
+                                }
                             }
                         )
                     }
@@ -507,7 +341,7 @@ private fun ChapterSearchBar(
                 trailingIcon = {
                     if (query.isNotEmpty()) {
                         IconButton(onClick = { onQueryChange("") }) {
-                            androidx.compose.material3.Icon(Icons.Filled.Clear, contentDescription = "Borrar")
+                            androidx.compose.material3.Icon(Icons.Filled.Clear, contentDescription = "Borrar texto")
                         }
                     }
                 }
@@ -520,6 +354,7 @@ private fun ChapterSearchBar(
                 IconToggleButton(checked = ignoreCase, onCheckedChange = { onToggleCase() }) {
                     androidx.compose.material3.Icon(Icons.Filled.FormatSize, contentDescription = "Mayúsculas")
                 }
+
             }
             TooltipBox(
                 positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
@@ -546,7 +381,15 @@ private fun ChapterSearchBar(
             ) {
                 IconButton(onClick = onNext) {
                     androidx.compose.material3.Icon(Icons.Filled.ArrowForward, contentDescription = "Siguiente")
-
+                }
+            }
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { Text("Cancelar") },
+                state = rememberTooltipState()
+            ) {
+                IconButton(onClick = onClose) {
+                    androidx.compose.material3.Icon(Icons.Filled.Close, contentDescription = "Cancelar")
                 }
             }
         }
@@ -574,8 +417,6 @@ private fun SearchResultsList(
         }
     }
 }
-
-
 /** Obtiene la ruta de un capítulo intentando nombres comunes: path / chapterPath / file / manifestPath */
 private fun chapterPathOf(chapter: Any): String {
     val candidates = listOf("path", "chapterPath", "file", "manifestPath")

--- a/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
+++ b/app/src/main/java/com/gio/guiasclinicas/ui/components/BigTablePro.kt
@@ -194,7 +194,7 @@ fun BigTableSectionView(
             pageRows.forEachIndexed { rIndex, r ->
 
                 // Repetimos encabezado cada N filas (barato, sin segundo scroll)
-                if (index > 0 && index % REPEAT_HEADER_EVERY == 0) {
+                if (rIndex > 0 && rIndex % REPEAT_HEADER_EVERY == 0) {
                     TableHeaderRow(
                         cols = cols,
                         colWidthsDp = colWidthsDp,


### PR DESCRIPTION
## Summary
- import missing Material3 APIs and remove duplicated search components
- correct search bar alignment and bottom sheet usage
- fix BigTable pagination header repetition index
- host bottom navigation in a top-level Scaffold wrapping the bottom sheet
- add search history dropdown with per-entry removal and text-clear action

## Testing
- `./gradlew app:compileDebugKotlin` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af951dd0d883208a87007882d3c7e5